### PR TITLE
add undef check.

### DIFF
--- a/KotoriBot/Server.pm
+++ b/KotoriBot/Server.pm
@@ -157,7 +157,7 @@ sub tick {
 
 		foreach my $channelhash (@{$self->{hash}->{channels}}) {
 			my $channelname = $channelhash->{name};
-			if ($channelhash->{persist} == 2 && !exists($self->{channels}->{$channelname})) {
+			if (defined($channelhash->{persist}) && $channelhash->{persist} == 2 && !exists($self->{channels}->{$channelname})) {
 				my $channelname_encoded = Encode::encode($channelhash->{encoding}, $channelname);
 				$self->{channelname_map}->{$channelname_encoded} = $channelname;
 				$self->join_channel_encoded($channelname_encoded);


### PR DESCRIPTION
// ご無沙汰しております。

kotoribot.conf にて、default_channel に、persist の設定がない場合など、当該箇所で、

`Use of uninitialized value in numeric eq (==) at perl5/KotoriBot/Server.pm line 162.
`

の警告が出る模様です。// kotoribot.conf.sample には、persist の設定はない模様です。

Core.pm の expand_serverhash()

                $ch->{persist} = 1 unless exists $ch->{persist};

を直す方が良いかもしれませんが、とりあえず、 undef check を入れることにより、修正してみました。
マージ等、ご検討して頂けますと、幸いです。